### PR TITLE
Add logging to ModuleSettingsController and fix issue with webpack.run.cmd script

### DIFF
--- a/src/DotNetNuke.PowerBI/PBIEmbedded.Web/webpack.run.cmd
+++ b/src/DotNetNuke.PowerBI/PBIEmbedded.Web/webpack.run.cmd
@@ -1,2 +1,2 @@
 cls
-SET NODE_ENV=development&&SET CUSTOM_DEV=&& webpack-dev-server
+set NODE_OPTIONS=--openssl-legacy-provider&&SET NODE_ENV=development&&SET CUSTOM_DEV=&& webpack-dev-server

--- a/src/DotNetNuke.PowerBI/Services/ModuleSettingsController.cs
+++ b/src/DotNetNuke.PowerBI/Services/ModuleSettingsController.cs
@@ -1,4 +1,6 @@
-﻿using DotNetNuke.PowerBI.Models;
+﻿using DotNetNuke.Instrumentation;
+using DotNetNuke.PowerBI.Controllers;
+using DotNetNuke.PowerBI.Models;
 using DotNetNuke.Security;
 using DotNetNuke.Web.Api;
 using System;
@@ -12,6 +14,8 @@ namespace DotNetNuke.PowerBI.Services
     [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.View)]
     public class ModuleSettingsController : DnnApiController
     {
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(ModuleSettingsController));
+
         [HttpGet]
         [DnnAuthorize]
         public HttpResponseMessage GetContentItemsByGroup(string groupId)
@@ -34,6 +38,7 @@ namespace DotNetNuke.PowerBI.Services
             }
             catch (Exception ex)
             {
+                Logger.Error(ex);
                 return Request.CreateResponse(HttpStatusCode.InternalServerError);
             }
         }


### PR DESCRIPTION
This pull request includes several changes to improve logging and address compatibility issues in the `DotNetNuke.PowerBI` project. The most important changes include updating the webpack configuration to handle legacy OpenSSL providers, adding logging functionality to the `ModuleSettingsController`, and enhancing error handling.

### Compatibility Improvements:

* [`src/DotNetNuke.PowerBI/PBIEmbedded.Web/webpack.run.cmd`](diffhunk://#diff-cfba6394c2769066d719994270d1f35b64aae2e7607887fac111a7425a0c6385L2-R2): Updated the webpack run command to include the `NODE_OPTIONS=--openssl-legacy-provider` environment variable to ensure compatibility with legacy OpenSSL providers.

### Logging Enhancements:

* [`src/DotNetNuke.PowerBI/Services/ModuleSettingsController.cs`](diffhunk://#diff-848db5a9be334f82977185df83c1e59b3ffbc30cf4098bb6dee888d0aed2ddbaL1-R3): Added a new `Logger` instance to the `ModuleSettingsController` class to enable logging. [[1]](diffhunk://#diff-848db5a9be334f82977185df83c1e59b3ffbc30cf4098bb6dee888d0aed2ddbaL1-R3) [[2]](diffhunk://#diff-848db5a9be334f82977185df83c1e59b3ffbc30cf4098bb6dee888d0aed2ddbaR17-R18)
* [`src/DotNetNuke.PowerBI/Services/ModuleSettingsController.cs`](diffhunk://#diff-848db5a9be334f82977185df83c1e59b3ffbc30cf4098bb6dee888d0aed2ddbaR41): Updated the `GetContentItemsByGroup` method to log errors when exceptions occur, improving error tracking and debugging.