### PR TITLE
Add title attributes to workspace, dashboard, and report items

### DIFF
--- a/src/DotNetNuke.PowerBI/Views/ListView/Index.cshtml
+++ b/src/DotNetNuke.PowerBI/Views/ListView/Index.cshtml
@@ -47,12 +47,13 @@
             if (Model.Workspaces.Count > 1)
             {
                 var currentSid = (string)ViewBag.SettingsGroupId ?? Request.QueryString["sid"];
-                var selectedWorkspaceName = Model.Workspaces.FirstOrDefault(w => w.Id == currentSid)?.Name ?? "";
+                var selectedWorkspace = Model.Workspaces.FirstOrDefault(w => w.Id == currentSid) ?? Model.Workspaces[0];
+                var selectedWorkspaceName = string.IsNullOrWhiteSpace(selectedWorkspace.Name) ? null : selectedWorkspace.Name;
                 <div class="workspacesSection">
                     <select class="workspace" title="@selectedWorkspaceName" onchange="return changeWorkspace();">
                         @foreach (var w in Model.Workspaces)
                         {
-                            <option value="@w.Id" @(currentSid == w.Id ? "selected": "")>@w.Name</option>
+                            <option value="@w.Id" @(selectedWorkspace.Id == w.Id ? "selected": "")>@w.Name</option>
                         }
                     </select>
                 </div>

--- a/src/DotNetNuke.PowerBI/Views/ListView/Index.cshtml
+++ b/src/DotNetNuke.PowerBI/Views/ListView/Index.cshtml
@@ -47,8 +47,9 @@
             if (Model.Workspaces.Count > 1)
             {
                 var currentSid = (string)ViewBag.SettingsGroupId ?? Request.QueryString["sid"];
+                var selectedWorkspaceName = Model.Workspaces.FirstOrDefault(w => w.Id == currentSid)?.Name ?? "";
                 <div class="workspacesSection">
-                    <select class="workspace" onchange="return changeWorkspace();">
+                    <select class="workspace" title="@selectedWorkspaceName" onchange="return changeWorkspace();">
                         @foreach (var w in Model.Workspaces)
                         {
                             <option value="@w.Id" @(currentSid == w.Id ? "selected": "")>@w.Name</option>
@@ -68,7 +69,7 @@
                     @foreach (var d in Model.Dashboards)
                     {
                         var sid = !string.IsNullOrEmpty(ViewBag.SettingsGroupId) ? "&sid=" + ViewBag.SettingsGroupId : "";
-                        <li class='normal@(d.Id.ToString() == Request["dashboardId"] ? " active" : "")'><a href='@ViewBag.ReportsPage?dashboardId=@d.Id@sid'>@d.DisplayName</a></li>
+                        <li class='normal@(d.Id.ToString() == Request["dashboardId"] ? " active" : "")'><a href='@ViewBag.ReportsPage?dashboardId=@d.Id@sid' title="@d.DisplayName">@d.DisplayName</a></li>
                     }
                 </ul>
             </div>
@@ -85,7 +86,7 @@
                     @foreach (var r in Model.Reports)
                     {
                         var sid = !string.IsNullOrEmpty(ViewBag.SettingsGroupId) ? "&sid=" + ViewBag.SettingsGroupId : "";
-                        <li class='normal@(r.Id.ToString() == Request["reportId"] ? " active" : "")'><a href='@ViewBag.ReportsPage?reportId=@r.Id@sid'>@r.Name</a></li>
+                        <li class='normal@(r.Id.ToString() == Request["reportId"] ? " active" : "")'><a href='@ViewBag.ReportsPage?reportId=@r.Id@sid' title="@r.Name">@r.Name</a></li>
                     }
                 </ul>
             </div>


### PR DESCRIPTION
**Summary**
Adds title attributes to the list view items so the full selected or displayed name is available on hover.

**Changes**

- Adds a title to the workspace selector using the currently selected workspace name
- Adds a title to dashboard links using the dashboard display name
- Adds a title to report links using the report name

**Why**
This improves usability and accessibility by exposing the full item name when text is truncated or when users hover over the control or links.

**Impact**
This change is UI-only and does not modify navigation logic, workspace switching behavior, or report/dashboard selection.