### PR TITLE
Refactor Power BI client initialization and role handling

### DIFF
--- a/src/DotNetNuke.PowerBI/Components/Common.cs
+++ b/src/DotNetNuke.PowerBI/Components/Common.cs
@@ -411,12 +411,9 @@ namespace DotNetNuke.PowerBI.Components
                     PowerBIReportConfiguration = powerBIReportExportConfiguration,
                 };
 
-                // The 'Client' object is an instance of the Power BI .NET SDK
-                {
-                    var client = new PowerBIClient(accessToken, new Uri(setting.ApiUrl));
-                    var export = (await client.Reports.ExportToFileInGroupAsync(Guid.Parse(setting.WorkspaceId), reportId, exportRequest).ConfigureAwait(false)).Value;
-                    return export.Id;
-                }
+                // The 'Client' object is an instance of the Power BI .NET SDK                
+                var export = (await client.Reports.ExportToFileInGroupAsync(Guid.Parse(setting.WorkspaceId), reportId, exportRequest).ConfigureAwait(false)).Value;
+                return export.Id;
             }
             catch (Exception e)
             {

--- a/src/DotNetNuke.PowerBI/Components/Common.cs
+++ b/src/DotNetNuke.PowerBI/Components/Common.cs
@@ -367,16 +367,10 @@ namespace DotNetNuke.PowerBI.Components
             {
                 PortalSettings portalSettings = new PortalSettings(0);
 
-                Reports reports;
-                Report report;
-                Dataset dataset;
-                {
-                    var client = new PowerBIClient(accessToken, new Uri(setting.ApiUrl));
-                    reports = (await client.Reports.GetReportsInGroupAsync(Guid.Parse(setting.WorkspaceId)).ConfigureAwait(false)).Value;
-                    report = reports.Value.FirstOrDefault(r => r.Id.ToString().Equals(reportId.ToString(), StringComparison.InvariantCultureIgnoreCase));
-                    dataset = (await client.Datasets.GetDatasetInGroupAsync(Guid.Parse(setting.WorkspaceId), report.DatasetId).ConfigureAwait(false)).Value;
-                }
-
+                PowerBIClient client = new PowerBIClient(accessToken, new Uri(setting.ApiUrl));
+                Reports reports = (await client.Reports.GetReportsInGroupAsync(Guid.Parse(setting.WorkspaceId)).ConfigureAwait(false)).Value;
+                Report report = reports.Value.FirstOrDefault(r => r.Id.ToString().Equals(reportId.ToString(), StringComparison.InvariantCultureIgnoreCase));
+                Dataset dataset = (await client.Datasets.GetDatasetInGroupAsync(Guid.Parse(setting.WorkspaceId), report.DatasetId).ConfigureAwait(false)).Value;
                 var powerBIReportExportConfiguration = new PowerBIReportExportConfiguration
                 {
                     Settings = new ExportReportSettings

--- a/src/DotNetNuke.PowerBI/Services/EmbedService.cs
+++ b/src/DotNetNuke.PowerBI/Services/EmbedService.cs
@@ -3,6 +3,7 @@ using Azure;
 using DotNetNuke.PowerBI.Data.Models;
 using DotNetNuke.PowerBI.Data.SharedSettings;
 using DotNetNuke.PowerBI.Models;
+using DotNetNuke.Security.Roles;
 using DotNetNuke.Services.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.PowerBI.Api;
@@ -10,6 +11,7 @@ using Microsoft.PowerBI.Api.Models;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -515,10 +517,7 @@ namespace DotNetNuke.PowerBI.Services
                         rls.Datasets.Add(report.DatasetId);
                         if (!string.IsNullOrWhiteSpace(roles) && dataset.IsEffectiveIdentityRolesRequired.GetValueOrDefault(false))
                         {
-                            foreach (var role in roles.Split(','))
-                            {
-                                rls.Roles.Add(role);
-                            }
+                            AppendEffectiveRoles(rls, roles);
                         }
                         identities = new List<EffectiveIdentity> { rls };
                     }
@@ -684,10 +683,7 @@ namespace DotNetNuke.PowerBI.Services
                                                      || chainedDatasets.Any(c => c.IsEffectiveIdentityRolesRequired);
                         if (!string.IsNullOrWhiteSpace(roles) && rolesRequiredAnywhere)
                         {
-                            foreach (var role in roles.Split(','))
-                            {
-                                rls.Roles.Add(role);
-                            }
+                            AppendEffectiveRoles(rls, roles);
                         }
                     }
                 }
@@ -900,6 +896,97 @@ namespace DotNetNuke.PowerBI.Services
             return name;
         }
 
+        // Power BI Embedded limits: max 50 roles per EffectiveIdentity, max 50 chars per role name.
+        // See https://learn.microsoft.com/rest/api/power-bi/embed-token/generate-token#effectiveidentity
+        private const int MaxRolesPerIdentity = 50;
+        private const int MaxRoleNameLength = 50;
+
+        /// <summary>
+        /// Filters and appends DNN roles to an <see cref="EffectiveIdentity"/> honoring the Power BI
+        /// limits (max 50 roles, max 50 chars per role name). If the appSetting "RLS.RoleGroupName"
+        /// is defined, only roles that belong to that DNN role group are included.
+        /// </summary>
+        private void AppendEffectiveRoles(EffectiveIdentity rls, string roles)
+        {
+            if (rls == null || string.IsNullOrWhiteSpace(roles))
+                return;
+
+            var roleList = roles.Split(',')
+                .Select(r => r?.Trim())
+                .Where(r => !string.IsNullOrEmpty(r))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            // Optional filter by role group configured in web.config
+            var roleGroupName = ConfigurationManager.AppSettings["RLS.RoleGroupName"];
+            if (!string.IsNullOrWhiteSpace(roleGroupName))
+            {
+                try
+                {
+                    var allowedRoles = GetRoleNamesInRoleGroup(roleGroupName);
+                    if (allowedRoles != null)
+                    {
+                        roleList = roleList
+                            .Where(r => allowedRoles.Contains(r, StringComparer.OrdinalIgnoreCase))
+                            .ToList();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn($"Error filtering roles by role group '{roleGroupName}'. Falling back to all roles.", ex);
+                }
+            }
+
+            // Warn (but don't fail) on roles whose name exceeds the Power BI limit; skip them.
+            var oversizedRoles = roleList.Where(r => r.Length > MaxRoleNameLength).ToList();
+            if (oversizedRoles.Count > 0)
+            {
+                Logger.Warn($"Power BI RLS: {oversizedRoles.Count} role(s) exceed the {MaxRoleNameLength}-character limit and will be skipped: {string.Join(", ", oversizedRoles)}");
+                roleList = roleList.Where(r => r.Length <= MaxRoleNameLength).ToList();
+            }
+
+            // Warn (but don't fail) when the effective identity would exceed Power BI's limit; truncate.
+            if (roleList.Count > MaxRolesPerIdentity)
+            {
+                Logger.Warn($"Power BI RLS: user has {roleList.Count} effective roles which exceeds the Power BI limit of {MaxRolesPerIdentity}. Only the first {MaxRolesPerIdentity} roles will be sent. Consider configuring the 'RLS.RoleGroupName' appSetting to filter roles by group.");
+                roleList = roleList.Take(MaxRolesPerIdentity).ToList();
+            }
+
+            foreach (var role in roleList)
+            {
+                rls.Roles.Add(role);
+            }
+        }
+
+        /// <summary>
+        /// Returns the names of the DNN roles that belong to the role group with the given name in
+        /// the current portal, or null if the role group cannot be resolved.
+        /// </summary>
+        private List<string> GetRoleNamesInRoleGroup(string roleGroupName)
+        {
+            var cacheKey = $"PBI_{Settings.PortalId}_RoleGroupRoles_{roleGroupName}";
+            var cached = CachingProvider.Instance().GetItem(cacheKey) as List<string>;
+            if (cached != null)
+                return cached;
+
+            var groups = RoleController.GetRoleGroups(Settings.PortalId).Cast<RoleGroupInfo>().ToList();
+            var group = groups.FirstOrDefault(g => string.Equals(g.RoleGroupName, roleGroupName, StringComparison.OrdinalIgnoreCase));
+            if (group == null)
+            {
+                Logger.Warn($"Power BI RLS: role group '{roleGroupName}' configured in 'RLS.RoleGroupName' was not found in portal {Settings.PortalId}.");
+                return null;
+            }
+
+            var allRoles = RoleController.Instance.GetRoles(Settings.PortalId);
+            var names = allRoles
+                .Where(r => r.RoleGroupID == group.RoleGroupID)
+                .Select(r => r.RoleName)
+                .ToList();
+
+            CachingProvider.Instance().Insert(cacheKey, names, null, DateTime.Now.AddMinutes(5), TimeSpan.Zero);
+            return names;
+        }
+
         private async Task<Guid?> GetReportDatasetWorkspaceIdAsync(Guid reportWorkspaceId, Guid reportId)
         {
             var cacheKey = $"PBI_{Settings.PortalId}_{Settings.SettingsId}_DatasetWorkspaceId_{reportWorkspaceId}_{reportId}";
@@ -1015,10 +1102,7 @@ namespace DotNetNuke.PowerBI.Services
                         rls.Datasets.Add(dashboardId);
                         if (!string.IsNullOrWhiteSpace(roles))
                         {
-                            foreach (var role in roles.Split(','))
-                            {
-                                rls.Roles.Add(role);
-                            }
+                            AppendEffectiveRoles(rls, roles);
                         }
                         if (Components.Common.IsSuperUser())
                         {


### PR DESCRIPTION
This pull request improves how DNN roles are handled for Power BI Row-Level Security (RLS) by introducing stricter enforcement of Power BI's limits on roles per EffectiveIdentity and role name length, and by adding optional filtering of roles by DNN role group. The changes also centralize and refactor the logic for appending roles, ensuring consistent enforcement of these rules across the codebase.

**Role Handling and Enforcement Improvements:**

* Added a new `AppendEffectiveRoles` method to `EmbedService.cs` that:
  * Enforces Power BI Embedded limits: maximum 50 roles per EffectiveIdentity and 50 characters per role name.
  * Optionally filters roles by a DNN role group, based on the `RLS.RoleGroupName` appSetting.
  * Logs warnings and skips roles that exceed Power BI's restrictions, and truncates the list if too many roles are present.
* Refactored all role-appending logic in `EmbedService.cs` to use the new `AppendEffectiveRoles` method, ensuring consistent enforcement in report export, token generation, and dashboard embedding. [[1]](diffhunk://#diff-0f4705c14d79ddd5db977de9ea4e1fdbaa615bc3a6e383b8b79a10e762ced9cfL518-R520) [[2]](diffhunk://#diff-0f4705c14d79ddd5db977de9ea4e1fdbaa615bc3a6e383b8b79a10e762ced9cfL687-R686) [[3]](diffhunk://#diff-0f4705c14d79ddd5db977de9ea4e1fdbaa615bc3a6e383b8b79a10e762ced9cfL1018-R1105)
* Added a helper method `GetRoleNamesInRoleGroup` to efficiently fetch and cache the names of roles in a given DNN role group.

**Minor Codebase Cleanups:**

* Removed unnecessary nested code blocks and redundant variable declarations in `Common.cs` for clarity and maintainability. [[1]](diffhunk://#diff-84f485b97fde3cff9a3d647c92ada0864a7e5137dd3e72282e150870e05c7e3aL370-R373) [[2]](diffhunk://#diff-84f485b97fde3cff9a3d647c92ada0864a7e5137dd3e72282e150870e05c7e3aL421-L426)
* Added missing `using` directives to support new functionality.